### PR TITLE
Fixed typo: accessing undefined variables.

### DIFF
--- a/LowerClass.lua
+++ b/LowerClass.lua
@@ -24,7 +24,7 @@ local classData = setmetatable({}, { __mode = "k" }) -- Stores class data
 --- @return table|function
 local function __createIndexWrapper(aClass, var)
     if var == nil then
-        return classData[aClass].lookupDict[name]
+        return classData[aClass].lookupDict
     elseif type(var) == "function" then
         return function(self, name)
             return var(self, name) or classData[aClass].lookupDict[name]
@@ -85,7 +85,7 @@ local function __addParent(aClass, parent)
     table.insert(classData[parent].heirarchyData.children, aClass)
 
     for key, value in pairs(classData[parent].definedVariables) do
-        if not (key == "__index" and type(f) == "table") then
+        if not (key == "__index" and type(value) == "table") then
             __propegateClassVariable(aClass, key, value)
         end
     end

--- a/LowerClass.min.lua
+++ b/LowerClass.min.lua
@@ -1,6 +1,6 @@
 local a = {}
 local b = setmetatable({}, { __mode = "k" })
-local function c(d, e) if e == nil then return b[d].lookupDict[name] elseif type(e) == "function" then return function(
+local function c(d, e) if e == nil then return b[d].lookupDict elseif type(e) == "function" then return function(
             self, name) return e(self, name) or b[d].lookupDict[name] end else return function(self, name) return e
             [name] or b[d].lookupDict[name] end end end; local function g(d, name, e)
     e = name == "__index" and c(d, e) or e; b[d].lookupDict[name] = e; for h, i in ipairs(b[d].heirarchyData.children) do if b[i].definedVariables[name] == nil then
@@ -13,7 +13,7 @@ end; local function j(d, name, e)
 end; local function m(d, l)
     table.insert(b[d].heirarchyData.parents, l)
     table.insert(b[l].heirarchyData.children, d)
-    for n, o in pairs(b[l].definedVariables) do if not (n == "__index" and type(f) == "table") then g(d, n, o) end end
+    for n, o in pairs(b[l].definedVariables) do if not (n == "__index" and type(o) == "table") then g(d, n, o) end end
 end; local function p(self, d)
     self = self.class or self; if self == d then return true end; local k = b[self]
     for h, l in ipairs(k.heirarchyData.parents) do if p(l, d) then return true end end; return false


### PR DESCRIPTION
1. `name` variable under __createIndexWrapper is totally based on middleclass.
2. `f` variable under __addParent is based on my own speculation.

Without these, it accesses global variables.